### PR TITLE
init.d/rancher-net: fix never-ending for loop

### DIFF
--- a/content/etc/init.d/rancher-net
+++ b/content/etc/init.d/rancher-net
@@ -37,7 +37,7 @@ set -e
 
 case "$1" in
   start)
-	for ((i=0; i<6; i=0)); do
+	for ((i=0; i<6; i++)); do
 		if ip xfrm state add src 1.1.1.1 dst 1.1.1.1 spi 42 proto esp mode tunnel aead "rfc4106(gcm(aes))" 0x0000000000000000000000000000000000000001 128 sel src 1.1.1.1 dst 1.1.1.1; then
 			GCM=true
 			break


### PR DESCRIPTION
Due to a typo, the for loop counter in the rancher-net init script
wasn't incremented, so rancher-net failed to start if GCM remained
false. As a consequence, inter-host communication was broken.
