### PR TITLE
Fixing cross env links issue due to change in metadata

### DIFF
--- a/store/metadata.go
+++ b/store/metadata.go
@@ -201,6 +201,10 @@ func (ms *MetadataStore) getLinkedPeersInfo() (map[string]bool, []metadata.Conta
 			} else {
 				for _, aService := range linkedServices {
 					for _, aContainer := range aService.Containers {
+						// Skip containers with --net=host
+						if aContainer.PrimaryIp == ms.info.hostsMap[aContainer.HostUUID].AgentIP {
+							continue
+						}
 						linkedPeersContainers = append(linkedPeersContainers, aContainer)
 						if _, ok := linkedPeersNetworks[aContainer.NetworkUUID]; !ok {
 							linkedPeersNetworks[aContainer.NetworkUUID] = true
@@ -213,6 +217,10 @@ func (ms *MetadataStore) getLinkedPeersInfo() (map[string]bool, []metadata.Conta
 		linkedFromServices := ms.getLinkedFromServicesToSelf()
 		for _, aService := range linkedFromServices {
 			for _, aContainer := range aService.Containers {
+				// Skip containers with --net=host
+				if aContainer.PrimaryIp == ms.info.hostsMap[aContainer.HostUUID].AgentIP {
+					continue
+				}
 				linkedPeersContainers = append(linkedPeersContainers, aContainer)
 				if _, ok := linkedPeersNetworks[aContainer.NetworkUUID]; !ok {
 					linkedPeersNetworks[aContainer.NetworkUUID] = true

--- a/store/metadata.go
+++ b/store/metadata.go
@@ -393,8 +393,9 @@ func (ms *MetadataStore) Reload() error {
 
 	selfNetwork, ok := networksMap[selfContainer.NetworkUUID]
 	if !ok {
-		logrus.Errorf("couldn't find selfNetwork: %v", err)
-		return fmt.Errorf("couldn't find self network in metadata")
+		errMsg := "couldn't find self network in metadata"
+		logrus.Errorf(errMsg)
+		return fmt.Errorf(errMsg)
 	}
 
 	info := &InfoFromMetadata{

--- a/store/metadata.go
+++ b/store/metadata.go
@@ -393,9 +393,7 @@ func (ms *MetadataStore) Reload() error {
 
 	selfNetwork, ok := networksMap[selfContainer.NetworkUUID]
 	if !ok {
-		errMsg := "couldn't find self network in metadata"
-		logrus.Errorf(errMsg)
-		return fmt.Errorf(errMsg)
+		return fmt.Errorf("couldn't find self network in metadata")
 	}
 
 	info := &InfoFromMetadata{


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/7957

Root cause: 
When environments are linked.

Before: (1.4.1 setup)
```
1=cni-driver
root@dd137f8ab366:/# curl rancher-metadata/2015-12-19/services/1/links
vxlan-user%2Fcni-driver
```

After: (rancher/server:master)
```
5=cni-driver
root@e1a081df8704:/# curl rancher-metadata/2015-12-19/services/5/links
vxlan-user%2Fvxlan
```

The cni-driver service's link has changed.

Due to this, the IP address of the cni-driver (IP address of the host) was considered as a VXLAN peer. This lead to a wrong route being programmed.

Summary of the fix:
~~Exclude the containers with host networking.~~
Exclude the containers whose network name doesn't match self.