### PR TITLE
Tolerate duplicate container in metadata

### DIFF
--- a/store/metadata.go
+++ b/store/metadata.go
@@ -254,6 +254,7 @@ func (ms *MetadataStore) doInternalRefresh() {
 
 	ms.self, _ = ms.getEntryFromContainer(ms.info.selfContainer)
 
+	seen := map[string]bool{}
 	entries := []Entry{}
 	local := map[string]Entry{}
 	remote := map[string]Entry{}
@@ -286,6 +287,12 @@ func (ms *MetadataStore) doInternalRefresh() {
 		e, _ := ms.getEntryFromContainer(c)
 
 		ipNoCidr := strings.Split(e.IpAddress, "/")[0]
+
+		if seen[ipNoCidr] {
+			continue
+		}
+		seen[ipNoCidr] = true
+
 		if _, ok := peersMap[ipNoCidr]; ok {
 			e.Peer = true
 		}


### PR DESCRIPTION
Since IP address is the key used in the store we should not duplicate
entries that have the same IP. Instead first one should win. Ideally
there shouldn't been two containers in metadata with the same IP but
given the eventually consistent nature, we should accommodate it
regardless.