### PR TITLE
using rancher/goStrongswanVici instead of upstream

### DIFF
--- a/trash.conf
+++ b/trash.conf
@@ -5,7 +5,7 @@ github.com/rancher/rancher-net
 
 cloud.google.com/go	v0.2.0-27-g8eb0f0f
 github.com/Sirupsen/logrus	v0.10.0-38-g3ec0642
-github.com/bronze1man/goStrongswanVici	385ce24
+github.com/bronze1man/goStrongswanVici	d5a3392 https://github.com/rancher/goStrongswanVici.git
 github.com/codegangsta/cli	v1.18.0-69-g55f715e
 github.com/golang/gddo	8b5538b
 github.com/gorilla/context	v1.1-7-g08b5f42

--- a/vendor/github.com/bronze1man/goStrongswanVici/clientConn.go
+++ b/vendor/github.com/bronze1man/goStrongswanVici/clientConn.go
@@ -4,6 +4,11 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"time"
+)
+
+const (
+	timeout = 15
 )
 
 // This object is not thread safe.
@@ -50,8 +55,8 @@ func (c *ClientConn) Request(apiname string, request map[string]interface{}) (re
 		fmt.Printf("error writing segment \n")
 		return
 	}
-	outMsg := <-c.responseChan
 
+	outMsg := c.readResponse()
 	if c.lastError != nil {
 		return nil, c.lastError
 	}
@@ -59,6 +64,18 @@ func (c *ClientConn) Request(apiname string, request map[string]interface{}) (re
 		return nil, fmt.Errorf("[%s] response error %d", apiname, outMsg.typ)
 	}
 	return outMsg.msg, nil
+}
+
+func (c *ClientConn) readResponse() segment {
+	select {
+	case outMsg := <-c.responseChan:
+		return outMsg
+	case <-time.After(timeout * time.Second):
+		if c.lastError == nil {
+			c.lastError = fmt.Errorf("Timeout waiting for message response")
+		}
+		return segment{}
+	}
 }
 
 func (c *ClientConn) RegisterEvent(name string, handler func(response map[string]interface{})) (err error) {
@@ -74,7 +91,7 @@ func (c *ClientConn) RegisterEvent(name string, handler func(response map[string
 		delete(c.eventHandlers, name)
 		return
 	}
-	outMsg := <-c.responseChan
+	outMsg := c.readResponse()
 	//fmt.Printf("registerEvent %#v\n", outMsg)
 	if c.lastError != nil {
 		delete(c.eventHandlers, name)
@@ -96,7 +113,7 @@ func (c *ClientConn) UnregisterEvent(name string) (err error) {
 	if err != nil {
 		return
 	}
-	outMsg := <-c.responseChan
+	outMsg := c.readResponse()
 	//fmt.Printf("UnregisterEvent %#v\n", outMsg)
 	if c.lastError != nil {
 		return c.lastError

--- a/vendor/github.com/bronze1man/goStrongswanVici/loadConn.go
+++ b/vendor/github.com/bronze1man/goStrongswanVici/loadConn.go
@@ -35,6 +35,7 @@ type ChildSAConf struct {
 	RekeyTime     string   `json:"rekey_time"`
 	Mode          string   `json:"mode"`
 	InstallPolicy string   `json:"policies"`
+	Updown        string   `json:"updown"`
 }
 
 func (c *ClientConn) LoadConn(conn *map[string]IKEConf) error {

--- a/vendor/github.com/bronze1man/goStrongswanVici/msg.go
+++ b/vendor/github.com/bronze1man/goStrongswanVici/msg.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"strconv"
 )
 
 type segmentType byte
@@ -301,6 +302,19 @@ func readKeyString(r *bufio.Reader) (key string, msg string, err error) {
 	return
 }
 
+func getKey(key string, msg map[string]interface{}) string {
+	if _, ok := msg[key]; !ok {
+		return key
+	}
+
+	for i := 0; ; i++ {
+		newKey := key + "##" + strconv.Itoa(i)
+		if _, ok := msg[newKey]; !ok {
+			return newKey
+		}
+	}
+}
+
 //SECTION_START has been read already.
 func readMap(r *bufio.Reader, isRoot bool) (msg map[string]interface{}, err error) {
 	msg = map[string]interface{}{}
@@ -318,19 +332,19 @@ func readMap(r *bufio.Reader, isRoot bool) (msg map[string]interface{}, err erro
 			if err != nil {
 				return nil, err
 			}
-			msg[key] = value
+			msg[getKey(key, msg)] = value
 		case etLIST_START:
 			key, value, err := readKeyList(r)
 			if err != nil {
 				return nil, err
 			}
-			msg[key] = value
+			msg[getKey(key, msg)] = value
 		case etKEY_VALUE:
 			key, value, err := readKeyString(r)
 			if err != nil {
 				return nil, err
 			}
-			msg[key] = value
+			msg[getKey(key, msg)] = value
 		case etSECTION_END: //end of outer section
 			return msg, nil
 		default:

--- a/vendor/github.com/bronze1man/goStrongswanVici/stats.go
+++ b/vendor/github.com/bronze1man/goStrongswanVici/stats.go
@@ -1,7 +1,0 @@
-package goStrongswanVici
-
-// Stats returns IKE daemon statistics and load information.
-func (c *ClientConn) Stats() (msg map[string]interface{}, err error) {
-	msg, err = c.Request("stats", nil)
-	return
-}


### PR DESCRIPTION
The package information was lost during the migration from `trash.yml` to `trash.conf`: https://github.com/rancher/rancher-net/commit/cff10a8aa2b1fc4383c2d31092d71c802d5ef2a4