### PR TITLE
Use only running/starting containers for setting up tunnels

### DIFF
--- a/store/metadata.go
+++ b/store/metadata.go
@@ -267,7 +267,14 @@ func (ms *MetadataStore) doInternalRefresh() {
 	// Add self network to peersNetworks
 	peersNetworks[ms.info.selfContainer.NetworkUUID] = true
 
-	allPeersContainers := append(ms.info.selfService.Containers, linkedPeersContainers...)
+	var allPeersContainers []metadata.Container
+	allPeersContainers = append(allPeersContainers, linkedPeersContainers...)
+	for _, c := range ms.info.selfService.Containers {
+		if c.State == "running" || c.State == "starting" {
+			allPeersContainers = append(allPeersContainers, c)
+		}
+	}
+
 	for _, sc := range allPeersContainers {
 		e, _ := ms.getEntryFromContainer(sc)
 		e.Peer = true


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/9389

As part of the fix for: #8684 (related PRs: rancher/cattle#2760, rancher/cattle#2766), the metadata started having information about stopped containers. Due to this during ipsec service upgrade, two tunnels started getting established for both running and stopped ipsec containers. This caused a disruption in traffic over the ipsec tunnel.

In this PR while setting up tunnels, consider only running/starting containers.